### PR TITLE
Add garbage collector command to launcher

### DIFF
--- a/launcher
+++ b/launcher
@@ -11,6 +11,7 @@ usage () {
   echo "    logs:       View the Docker container logs"
   echo "    bootstrap:  Bootstrap the container based on a template"
   echo "    rebuild:    Rebuild the container (destroy old, bootstrap, start new)"
+  echo "    gc:         Start the seafile garbage collector (stops seafile, starts gc, restarts container)"
   echo
   echo "Options:"
   echo "    --skip-prereqs             Don't check launcher prerequisites"
@@ -224,6 +225,25 @@ restart() {
     start
 }
 
+gc() {
+    ensure_container_running
+    (
+        loginfo "Stop seafile and start garbage collector"
+        docker exec -it seafile /bin/bash -c "\
+            /opt/seafile/seafile-server-latest/seafile.sh stop; \
+            sleep 10; \
+            /opt/seafile/seafile-server-latest/seaf-gc.sh >> /var/log/gc.log; \
+            sleep 3"
+        loginfo "Garbage collector finished! Restart container..."
+        running=$(docker ps | awk '{ print $1, $(NF) }' | grep " seafile$" | awk '{ print $1 }' || true)
+        if [[ $running == "" ]]; then
+            start
+        else
+            restart
+        fi
+    )
+}
+
 check_prereqs() {
     if [[ $SKIP_PREREQS == "true" ]]; then
         return 0
@@ -391,7 +411,7 @@ main() {
     while [[ $# -gt 0 ]]
     do
         case "$1" in
-            bootstrap|start|stop|restart|enter|destroy|logs|rebuild|manual-upgrade)
+            bootstrap|start|stop|restart|enter|destroy|logs|rebuild|manual-upgrade|gc)
                                                 action=${1//-/_}            ; shift 1 ;;
             -h|--help)                          ( usage ; exit 1)           ; shift 1 ;;
             -v|--verbose)                       verbose=true                ; shift 1 ;;


### PR DESCRIPTION
The seafile garbage collector can be started via the `gc` command option of the `launcher`.
This will stop the seafile-server inside the container, then run the `seaf-gc.sh` script and redirect its output to `/var/log/gc.log`.
Afterwards the whole container will be restarted.

It is based on the [gc-cleanup-script](https://manual.seafile.com/maintain/seafile_gc.html#gc-cleanup-script-for-community-version) shown in the seafile documentation.